### PR TITLE
#6 correct production url for API

### DIFF
--- a/iql-lesson-sync/src/iql_lesson_sync/__init__.py
+++ b/iql-lesson-sync/src/iql_lesson_sync/__init__.py
@@ -7,7 +7,7 @@ from .upload import Lesson, API
 CONF_FILE = "./iql.conf.yaml"
 API_URLS = {
     "staging": "https://learning-api-dev.quantum-computing.ibm.com",
-    "production": "learning-api.quantum-computing.ibm.com"
+    "production": "https://learning-api.quantum-computing.ibm.com"
 }
 WEBSITE_URLS = {
     "staging": "https://learning.www-dev.quantum-computing.ibm.com",


### PR DESCRIPTION
Corrects production url for API

Testing
--

It looks as if the URL is fixed. I cannot yet test to completion - now appears to be a different issue (for me) - ie API token to sort:

```
✅ Found token for production
❌ Push Introduction: Finding English translation...
.
requests.exceptions.HTTPError: 401 Client Error: Unauthorized for url: https://learning-api.quantum-computing.ibm.com/items/lessons/cb7f673b-abf4-4c61-bdfc-4e1b40ff5d50?fields%5B%5D=translations.id,translations.languages_code
```

but that's not relevant for this PR (other than incomplete test!)