### PR TITLE
Skip lessons with missing IDs

### DIFF
--- a/iql-lesson-sync/src/iql_lesson_sync/__init__.py
+++ b/iql-lesson-sync/src/iql_lesson_sync/__init__.py
@@ -72,7 +72,10 @@ def parse_yaml(api_name):
     output = {}
     for lesson in api_info["lessons"]:
         path = lesson["path"]
-        lesson_id = lesson[f"id{api_name.lower().capitalize()}"]
+        lesson_id = lesson.get(f"id{api_name.lower().capitalize()}", None)
+        if lesson_id is None:
+            print(f"ℹ️ No ID found for {path}; skipping")
+            continue
         output[path] = lesson_id
 
     return output


### PR DESCRIPTION
If no ID found in `iql.conf.yml`, then skip that lesson and print a message.

Fixes #8.

---

Here's a test:

<img width="943" alt="Screenshot 2023-09-22 at 12 38 38" src="https://github.com/frankharkins/learning-content-tools/assets/36071638/b901f4e8-2964-4879-b07b-2a6401eec4bd">
