### PR TITLE
Handle switches and add option to hide urls

### DIFF
--- a/iql-lesson-sync/src/iql_lesson_sync/__init__.py
+++ b/iql-lesson-sync/src/iql_lesson_sync/__init__.py
@@ -38,11 +38,44 @@ def get_api_name():
     print("Trying again...")
     return get_api_name()
 
+def get_switch(switch, pop=True):
+    """
+    Return True if switch in sys.argv, else False
+    If `pop`, also remove switch from sys.argv
+    """
+    if switch not in sys.argv:
+        return False
+    if pop:
+        sys.argv.remove(switch)
+    return True
+
+def check_for_unrecognized_switches():
+    for arg in sys.argv:
+        if arg.startswith("-"):
+            print(f"Unsupported argument: \"{arg}\"")
+            sys.exit(1)
+
 
 def sync_lessons():
-    print()
+    if get_switch("--help"):
+        print(
+            "Usage: sync-notebooks [ path(s)/to/specific/notebook(s) ]\n"
+            "Optional switches:\n"
+            "  --hide-urls:  Don't print URLs after uploading a lesson\n"
+            "  --help: Show this message and exit"
+        )
+        sys.exit()
+    hide_urls = get_switch("--hide-urls")
+    check_for_unrecognized_switches()
+    
+
     api_name = get_api_name()
-    api = API(api_name, API_URLS[api_name], WEBSITE_URLS[api_name])
+    api = API(
+        name=api_name,
+        api_url=API_URLS[api_name],
+        website_url=WEBSITE_URLS[api_name],
+        hide_urls=hide_urls
+    )
 
     lesson_ids = parse_yaml(api_name)
     if len(sys.argv) > 1:

--- a/iql-lesson-sync/src/iql_lesson_sync/upload.py
+++ b/iql-lesson-sync/src/iql_lesson_sync/upload.py
@@ -32,11 +32,12 @@ class Lesson:
 
 
 class API:
-    def __init__(self, name, api_url, website_url):
+    def __init__(self, name, api_url, website_url, hide_urls=False):
         self.name = name
         self.url = api_url
         self.website_url = website_url
         self.auth_header = {"Authorization": f"Bearer {self.get_access_token()}"}
+        self.hide_urls = hide_urls
 
     def get_access_token(self):
         """
@@ -95,8 +96,9 @@ class API:
         spinner.text = base_msg
         spinner.ok("✅")
 
-        print(f"   \033[30m╷\033[0m Web page: \033[96m{web_page}\033[0m")
-        print(f"   \033[30m╵\033[0m Lesson data: \033[96m{self.url}/admin/content/lessons/{lesson.id}\033[0m")
+        if not self.hide_urls:
+            print(f"   \033[30m╷\033[0m Web page: \033[96m{web_page}\033[0m")
+            print(f"   \033[30m╵\033[0m Lesson data: \033[96m{self.url}/admin/content/lessons/{lesson.id}\033[0m")
 
     def _push(self, lesson: Lesson, log):
         """


### PR DESCRIPTION
We want to be able to disable printing URLs in some CI logs. This PR adds the ability to handle switches, then uses this ability to add two switches
- `--hide-urls`, which disables printing URLs
- `--help`, which prints a help message then exits